### PR TITLE
Add section "Other DH Tools Lists, Directories, Collections, Catalogs & Repositories"

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,3 +48,4 @@ This is a curated list of tools and services supporting the Digital Humanities.
 * [GO::DH](http://www.globaloutlookdh.org/) - The purpose of Global Outlook::Digital Humanities (GO::DH) is to help break down barriers that hinder communication and collaboration among researchers and students of the Digital Arts, Humanities, and Cultural Heritage sectors in high, mid, and low income economies.
 
 ## Other DH Tools Lists, Directories, Collections, Catalogs & Repositories
+* [DiRT (Digital Research Tools)](https://dirtdirectory.org/) - The DiRT Directory is a registry of digital research tools for scholarly use. DiRT makes it easy for digital humanists and others conducting digital research to find and compare resources ranging from content management systems to music OCR, statistical analysis packages to mind-mapping software.

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ This is a curated list of tools and services supporting the Digital Humanities.
 ## Other DH Tools Lists, Directories, Collections, Catalogs & Repositories
 * [DiRT (Digital Research Tools)](https://dirtdirectory.org/) - The DiRT Directory is a registry of digital research tools for scholarly use. DiRT makes it easy for digital humanists and others conducting digital research to find and compare resources ranging from content management systems to music OCR, statistical analysis packages to mind-mapping software.
 
-* [TAPoR 3](http://tapor-test.artsrn.ualberta.ca/home) - TAPoR is a gateway to the tools used in sophisticated text analysis and retrieval. It was redesigned in order to integrate the DiRT (Digital Research Tools) directory.
+* [TAPoR 3](http://tapor.ca/home) - TAPoR is a gateway to the tools used in sophisticated text analysis and retrieval. It was redesigned in order to integrate the DiRT (Digital Research Tools) directory.
 
 * [DH Toychest](http://dhresourcesforprojectbuilding.pbworks.com/w/page/69244319/Digital%20Humanities%20Tools) - Guides, tools, and other resources for practical work in the digital humanities by researchers, teachers, and students. Curated by [Alan Liu](http://liu.english.ucsb.edu/), University of California, Santa Barbara.
 

--- a/README.md
+++ b/README.md
@@ -49,3 +49,5 @@ This is a curated list of tools and services supporting the Digital Humanities.
 
 ## Other DH Tools Lists, Directories, Collections, Catalogs & Repositories
 * [DiRT (Digital Research Tools)](https://dirtdirectory.org/) - The DiRT Directory is a registry of digital research tools for scholarly use. DiRT makes it easy for digital humanists and others conducting digital research to find and compare resources ranging from content management systems to music OCR, statistical analysis packages to mind-mapping software.
+
+* [TAPoR 3](http://tapor-test.artsrn.ualberta.ca/home) - TAPoR is a gateway to the tools used in sophisticated text analysis and retrieval. It was redesigned in order to integrate the DiRT (Digital Research Tools) directory.

--- a/README.md
+++ b/README.md
@@ -53,3 +53,5 @@ This is a curated list of tools and services supporting the Digital Humanities.
 * [TAPoR 3](http://tapor-test.artsrn.ualberta.ca/home) - TAPoR is a gateway to the tools used in sophisticated text analysis and retrieval. It was redesigned in order to integrate the DiRT (Digital Research Tools) directory.
 
 * [DH Toychest](http://dhresourcesforprojectbuilding.pbworks.com/w/page/69244319/Digital%20Humanities%20Tools) - Guides, tools, and other resources for practical work in the digital humanities by researchers, teachers, and students. Curated by [Alan Liu](http://liu.english.ucsb.edu/), University of California, Santa Barbara.
+
+* [Digital Textuality Resource Pages](http://digitaltextuality.pbworks.com/w/page/68178062/Digital%20Textuality%20Resource%20Pages) - Inspired by Alan Liu's ToyChest, Kimberly Knight and her students at U. Texas (Dallas) keep in this repository a list of tools for text production, visualization, still image work, sound work, and video and animation; includes some student reviews of tools.

--- a/README.md
+++ b/README.md
@@ -57,3 +57,5 @@ This is a curated list of tools and services supporting the Digital Humanities.
 * [Digital Textuality Resource Pages](http://digitaltextuality.pbworks.com/w/page/68178062/Digital%20Textuality%20Resource%20Pages) - Inspired by Alan Liu's ToyChest, Kimberly Knight and her students at U. Texas (Dallas) keep in this repository a list of tools for text production, visualization, still image work, sound work, and video and animation; includes some student reviews of tools.
 
 * [Duke University's DH Tools catalog](https://digitalhumanities.duke.edu/tools) - This list includes tools that Duke supports and tools that have been used by Duke digital projects. Some of the tools are made specifically for DH and others that can be re-purposed quite effectively for Humanities research.
+
+* [Carolina Digital Humanities Initiative Tools Page](http://digitalhumanities.unc.edu/resources/tools/) - It provides a range of platforms, plug-ins, readings, and other items that might be of use for DH researchers.

--- a/README.md
+++ b/README.md
@@ -55,3 +55,5 @@ This is a curated list of tools and services supporting the Digital Humanities.
 * [DH Toychest](http://dhresourcesforprojectbuilding.pbworks.com/w/page/69244319/Digital%20Humanities%20Tools) - Guides, tools, and other resources for practical work in the digital humanities by researchers, teachers, and students. Curated by [Alan Liu](http://liu.english.ucsb.edu/), University of California, Santa Barbara.
 
 * [Digital Textuality Resource Pages](http://digitaltextuality.pbworks.com/w/page/68178062/Digital%20Textuality%20Resource%20Pages) - Inspired by Alan Liu's ToyChest, Kimberly Knight and her students at U. Texas (Dallas) keep in this repository a list of tools for text production, visualization, still image work, sound work, and video and animation; includes some student reviews of tools.
+
+* [Duke University's DH Tools catalog](https://digitalhumanities.duke.edu/tools) - This list includes tools that Duke supports and tools that have been used by Duke digital projects. Some of the tools are made specifically for DH and others that can be re-purposed quite effectively for Humanities research.

--- a/README.md
+++ b/README.md
@@ -51,3 +51,5 @@ This is a curated list of tools and services supporting the Digital Humanities.
 * [DiRT (Digital Research Tools)](https://dirtdirectory.org/) - The DiRT Directory is a registry of digital research tools for scholarly use. DiRT makes it easy for digital humanists and others conducting digital research to find and compare resources ranging from content management systems to music OCR, statistical analysis packages to mind-mapping software.
 
 * [TAPoR 3](http://tapor-test.artsrn.ualberta.ca/home) - TAPoR is a gateway to the tools used in sophisticated text analysis and retrieval. It was redesigned in order to integrate the DiRT (Digital Research Tools) directory.
+
+* [DH Toychest](http://dhresourcesforprojectbuilding.pbworks.com/w/page/69244319/Digital%20Humanities%20Tools) - Guides, tools, and other resources for practical work in the digital humanities by researchers, teachers, and students. Curated by [Alan Liu](http://liu.english.ucsb.edu/), University of California, Santa Barbara.

--- a/README.md
+++ b/README.md
@@ -46,3 +46,5 @@ This is a curated list of tools and services supporting the Digital Humanities.
 * [Digital Humanities Now](http://digitalhumanitiesnow.org/) - Digital Humanities Now is an experimental, edited publication that highlights and distributes informally published digital humanities scholarship and resources from the open web.
 
 * [GO::DH](http://www.globaloutlookdh.org/) - The purpose of Global Outlook::Digital Humanities (GO::DH) is to help break down barriers that hinder communication and collaboration among researchers and students of the Digital Arts, Humanities, and Cultural Heritage sectors in high, mid, and low income economies.
+
+## Other DH Tools Lists, Directories, Collections, Catalogs & Repositories


### PR DESCRIPTION
Suggestion: Add section "Other DH Tools Lists, Directories, Collections, Catalogs & Repositories".

Since we are probably not going to provide an exhaustive list of tools available for use in Digital Humanities research, I believe it would be useful to point out other catalogs that have similar (if not the same) objectives as this repository.

This pull request also includes the following catalogs: DiRT, TAPoR 3, DH Toychest, Digital Textuality Resource Pages, Duke University's DH Tools catalog, and Carolina Digital Humanities Initiative Tools Page.