### PR TITLE
Changing the repository title from "Awesome DH Tools" to "Awesome Digital Humanities"

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Awesome DH tools
+# Awesome Digital Humanities
 
 [![Awesome](https://cdn.rawgit.com/sindresorhus/awesome/d7305f38d29fed78fa85652e3a63e154dd8e8829/media/badge.svg)](https://github.com/sindresorhus/awesome)
 


### PR DESCRIPTION
This pull request originated from a discussion in #6.

I believe this repository has grown more than the original scope (DH tools) since it now also supports organizations, tutorials, user guides,...

What do you think about changing its scope from "Awesome DH Tools" to "Awesome Digital Humanities"? 

This change would give us more freedom to create a more comprehensive list and be able to create sessions that could, for example, incorporate contributions like taxonomies (e.g. TaDiRAH).