### PR TITLE
Add ePubLangMerger to Publishing

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@ This is a curated list of tools, resources, and services supporting the Digital 
 ## Publishing
 
 - [CollectionBuilder](https://collectionbuilder.github.io/) - Open source tool for creating digital collection and exhibition websites based on metadata and powered by modern static web technology.
+- [ePubLangMerger](https://github.com/GeiserX/ePubLangMerger) - Merges two ePub files in different languages into a single bilingual ebook for parallel reading.
 - [Manifold](https://manifoldapp.org/) - Scholarly publishing and collaborative and social reading platform.
 - [Omeka](https://omeka.org/) - Open-source web publishing platform for sharing digital collections and creating media-rich online exhibits.
 - [Wax](https://minicomp.github.io/wax/) - Jekyll based framework for minimal exhibitions with IIIF.


### PR DESCRIPTION
Adds [ePubLangMerger](https://github.com/GeiserX/ePubLangMerger) — an R/Shiny web app that merges two ePub files in different languages into a single bilingual ebook for paragraph-level parallel reading. Available as a Docker container.