### PR TITLE
Add Wayback-Archive to Data Collection

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ This is a curated list of tools, resources, and services supporting the Digital 
 - [Trafilatura](https://trafilatura.readthedocs.io/) - Open source software to gather text and metadata on the Web: Crawling, scraping, extraction, output in multiple formats. Usable with Python, R and on the command-line.
 - [Transkribus](https://transkribus.eu/) - Transcribe. Collaborate. Share and benefit from cutting edge research in Handwritten Text Recognition!
 - [Textgrid](https://textgrid.de/) - Open source tools and services support humanistic scholars during the entire process of research, especially in digital scholarly editing.
+- [Wayback-Archive](https://github.com/GeiserX/Wayback-Archive) - Download complete websites from the Wayback Machine with full asset preservation for offline viewing. Python, GPL-3.0.
 - [webrecorder.io](https://webrecorder.io/) - Web archiving service anyone can use for free to save web pages.
 
 ## Data Analysis

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ This is a curated list of tools, resources, and services supporting the Digital 
 - [Trafilatura](https://trafilatura.readthedocs.io/) - Open source software to gather text and metadata on the Web: Crawling, scraping, extraction, output in multiple formats. Usable with Python, R and on the command-line.
 - [Transkribus](https://transkribus.eu/) - Transcribe. Collaborate. Share and benefit from cutting edge research in Handwritten Text Recognition!
 - [Textgrid](https://textgrid.de/) - Open source tools and services support humanistic scholars during the entire process of research, especially in digital scholarly editing.
-- [Wayback-Archive](https://github.com/GeiserX/Wayback-Archive) - Download complete websites from the Wayback Machine with full asset preservation for offline viewing. Python, GPL-3.0.
+- [Wayback-Archive](https://github.com/GeiserX/Wayback-Archive) - Download complete websites from the Wayback Machine with full asset preservation for offline viewing.
 - [webrecorder.io](https://webrecorder.io/) - Web archiving service anyone can use for free to save web pages.
 
 ## Data Analysis


### PR DESCRIPTION
## Summary

- Adds [Wayback-Archive](https://github.com/GeiserX/Wayback-Archive) to the **Data Collection** section in alphabetical order.

## Short pitch

**Wayback-Archive** is an open-source Python tool (GPL-3.0) that downloads complete websites from the Internet Archive's Wayback Machine with full asset preservation (HTML, CSS, JS, images) for offline viewing. This is particularly useful for digital humanities researchers who need to recover and study historical web content that may no longer be available online — enabling analysis of how websites, digital publications, and online cultural artifacts have evolved or disappeared over time.

## Checklist

- [x] One new entry per pull request
- [x] Entry placed in alphabetical order within the Data Collection section
- [x] Entry is not on the rejected list
- [x] Table of contents unchanged (no new section added)