### PR TITLE
Add FoJin to Platforms section

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ This is a curated list of tools, resources, and services supporting the Digital 
 ## Platforms
 
 - [DHSlack](https://github.com/amandavisconti/DHslack/blob/master/CodeOfConduct.md) - Slack channels for digital humanities scholars.
+- [FoJin](https://github.com/xr843/fojin) - Open-source Buddhist digital text platform aggregating 440+ sources across 30 languages. Features full-text search, knowledge graph, AI Q&A, and parallel reading.
 - [HSS Digital](https://hssonline.org/page/digitalprojects) - Digital scholarship in the history of science initiative.
 - [Perspectives on History](https://www.historians.org/community-careers/digital-history-resources/) - The newsmagazine of the American Historical Association.
 - [wethink.hypotheses.org](https://wethink.hypotheses.org/) - Collaborative Digital History.


### PR DESCRIPTION
## Summary

- Adds [FoJin](https://github.com/xr843/fojin) to the **Platforms** section (alphabetically placed between DHSlack and HSS Digital).

## Short pitch

FoJin is an open-source Buddhist digital text platform that aggregates 440+ data sources across 30 languages. It provides full-text search over thousands of canonical texts (via Elasticsearch), a knowledge graph of Buddhist entities and relations, AI-powered Q&A using RAG, and a parallel reading interface. Built with FastAPI, React, PostgreSQL (pgvector), and Elasticsearch, it serves as a comprehensive research environment for Buddhist studies scholars working with multilingual textual corpora.

🤖 Generated with [Claude Code](https://claude.com/claude-code)