### PR TITLE
Add CDH Princeton to list of DH centers

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ This is a curated list of tools, resources, and services supporting the Digital 
 ## DH Centers
 
 - [ACDH-DH](https://www.oeaw.ac.at/acdh/) - Austrian Centre for Digital Humanities.
+- [CDH Princeton](https://cdh.princeton.edu/) - Center for Digital Humanities at Princeton University.
 - [DHCenter UNIL-EPFL](https://dhcenter-unil-epfl.com/) - Founded in 2018, this interdisciplinary research platform connects digital humanities researchers across institutions.
 - [Digital Humanities Bern](https://www.dh.unibe.ch/) - It explores different topics, in the context of digital text and image analysis, digital edition, and reflection on the impact of digital methods on the humanities.
 - [Digital Humanities Lab - Universität Basel](https://dhlab.philhist.unibas.ch/en/) - An interdisciplinary institution of the University of Basel.


### PR DESCRIPTION
Add CDH Princeton to the "DH Centers" section.

**Short pitch**

I saw there was a list of DH Centers and CDH was not on it. I think we should be listed because we are awesome. 😁 😎 

I didn't add a description because I wasn't sure how to briefly encapsulate the many different things we do.

More seriously, CDH Princeton is a major player in terms of DH centers (esp. US-based), one of the leaders in humanities RSE, first US-based org to be a DARIAH partner.  

## Checklist

- [x] I have read and understood the [contribution guidelines](https://github.com/writing-resources/awesome-scientific-writing/blob/main/CONTRIBUTING.md).
- [x] Table of contents has been updated (if a section is added / removed).
- [x] Contents have been sorted alphabetically.

<!-- NOTE: Please do not skip the template -->
